### PR TITLE
Replace rp handler service with single instance of it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
-# EOSC Profile service
+# EOSC User Dashboard
 
 ## Description
 The Profile Service is meant to share user information's 
 between other services to improve a recommendations' system.
+
+## Run backend
+
+```bash
+cd backend
+docker-compose up -d --build
+```
+
+## Run frontend
+
+```bash
+cd ui
+npm start
+```

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -18,6 +18,7 @@ DATABASE_URL = config(
     default=f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{POSTGRES_SERVER}:{POSTGRES_PORT}/{POSTGRES_DB}"
 )
 
+UI_DOMAIN = config("UI_DOMAIN", cast=str, default="http://localhost:4200")
 DOMAIN = config("DOMAIN", cast=str, default='localhost')
 DOMAIN_PORT = config("DOMAIN_PORT", cast=int, default=8000)
 HOST = config("OIDC_HOST", cast=str, default=f'http://{DOMAIN}{f":{DOMAIN_PORT}" if DOMAIN_PORT else ""}')

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -3,24 +3,24 @@ from uuid import uuid4, UUID
 from fastapi import APIRouter, Depends, Response
 from starlette import status
 
-from starlette.responses import RedirectResponse, JSONResponse
+from starlette.responses import RedirectResponse
 from fastapi import HTTPException
 
-from app.core.config import OIDC_ISSUER
+from app.core.config import OIDC_ISSUER, UI_DOMAIN
 from app.schemas.LogoutResponse import LogoutResponse
 from app.schemas.SessionData import SessionData
 from app.schemas.UserInfoResponse import UserInfoResponse
-from app.services.rp_handler_service import RpHandlerService
 
 from app.utils.cookie_validators import backend, cookie, verifier
+from app.utils.rp_handler import rp_handler
 
 router = APIRouter()
 
 
 @router.get("/request")
-async def request(rph_service=Depends(RpHandlerService)):
+async def request():
     try:
-        result = rph_service.handler.begin(issuer_id=OIDC_ISSUER)
+        result = rp_handler.begin(issuer_id=OIDC_ISSUER)
     except Exception as err:
         raise HTTPException(status_code=400, detail=f'Something went wrong: {err} {repr(err)}')
     else:
@@ -28,24 +28,24 @@ async def request(rph_service=Depends(RpHandlerService)):
 
 
 @router.get("/checkin")
-async def checkin(code: str, state: str, rph_service=Depends(RpHandlerService)):
+async def checkin(code: str, state: str):
     if not state:
-        return RedirectResponse(status_code=400, url="http://localhost:4200")
+        return RedirectResponse(status_code=400, url=UI_DOMAIN)
 
     try:
-        aai_response = rph_service.handler.finalize(OIDC_ISSUER, dict(code=code, state=state))
+        aai_response = rp_handler.finalize(OIDC_ISSUER, dict(code=code, state=state))
 
         session_id = uuid4()
         username = aai_response["userinfo"]["name"]
         session_data = SessionData(username=username, aai_state=state)
         await backend.create(session_id, session_data)
-        auth_response = RedirectResponse(status_code=303, url="http://localhost:4200")
+        auth_response = RedirectResponse(status_code=303, url=UI_DOMAIN)
         cookie.attach_to_response(auth_response, session_id)
         return auth_response
     except Exception:
         return RedirectResponse(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            url="http://localhost:4200",
+            url=UI_DOMAIN,
             headers={"WWW-Authenticate": "Bearer"}
         )
 

--- a/backend/app/schemas/SessionData.py
+++ b/backend/app/schemas/SessionData.py
@@ -1,6 +1,9 @@
+from typing import Optional, Any
+
 from pydantic import BaseModel
 
 
 class SessionData(BaseModel):
-    username: str
-    aai_state: str
+    username: Optional[str]
+    aai_state: Optional[str]
+    rp_handler: Any


### PR DESCRIPTION
According to [OIDC RP documentation](https://oidcrp.readthedocs.io/en/latest/rp_handler.html#rp-handler-api) RP Handler instance store session of each started request into AAI.

```
A session is defined as a sequence of services used to cope with authorization/authentication for one user starting with the authorization request.